### PR TITLE
Add example sealed interface with cross-cutting sealed interfaces

### DIFF
--- a/shared/src/commonMain/kotlin/chat/quill/data/CrossSealedInterface.kt
+++ b/shared/src/commonMain/kotlin/chat/quill/data/CrossSealedInterface.kt
@@ -1,0 +1,23 @@
+package chat.quill.data
+
+sealed interface CrossSealedInterface {
+  sealed interface WithFoo : CrossSealedInterface {
+    val foo: String
+  }
+
+  sealed interface WithBar : CrossSealedInterface {
+    val bar: String
+  }
+
+  sealed class A : CrossSealedInterface {
+    data class AFoo(override val foo: String) : A(), WithFoo
+    data class ABar(override val bar: String) : A(), WithBar
+    data class AFooBar(override val foo: String, override val bar: String) : A(), WithFoo, WithBar
+  }
+
+  sealed class B : CrossSealedInterface {
+    data class BFoo(override val foo: String) : B(), WithFoo
+    data class BBar(override val bar: String) : B(), WithBar
+    data class BFooBar(override val foo: String, override val bar: String) : B(), WithFoo, WithBar
+  }
+}


### PR DESCRIPTION
SKIE generates the following enum:
```
extension MyKMPLib.Skie.Shared.CrossSealedInterface {
    @frozen
    public enum __Sealed {
        case a(MyKMPLib.CrossSealedInterfaceA)
        case b(MyKMPLib.CrossSealedInterfaceB)
        case withBar(MyKMPLib.CrossSealedInterfaceWithBar)
        case withFoo(MyKMPLib.CrossSealedInterfaceWithFoo)
    }
}
```
Should it be smart enough to know that I want A and B to be the only entries in that enum?  Or is there some way I can tell it that?